### PR TITLE
マッチ設定の性別表示を男女アイコンへ変更

### DIFF
--- a/lib/presentation/screens/player_list_screen.dart
+++ b/lib/presentation/screens/player_list_screen.dart
@@ -685,13 +685,13 @@ class _PlayerListScreenState extends State<PlayerListScreen> {
                         segments: const <ButtonSegment<Gender>>[
                           ButtonSegment<Gender>(
                             value: Gender.male,
-                            label: Text('男性'),
                             icon: Icon(Icons.male),
+                            tooltip: '男性',
                           ),
                           ButtonSegment<Gender>(
                             value: Gender.female,
-                            label: Text('女性'),
                             icon: Icon(Icons.female),
+                            tooltip: '女性',
                           ),
                         ],
                         selected: <Gender>{selectedGender},
@@ -1057,13 +1057,13 @@ class _PlayerListScreenState extends State<PlayerListScreen> {
                                   segments: const <ButtonSegment<Gender>>[
                                     ButtonSegment<Gender>(
                                       value: Gender.male,
-                                      label: Text('男性'),
                                       icon: Icon(Icons.male),
+                                      tooltip: '男性',
                                     ),
                                     ButtonSegment<Gender>(
                                       value: Gender.female,
-                                      label: Text('女性'),
                                       icon: Icon(Icons.female),
+                                      tooltip: '女性',
                                     ),
                                   ],
                                   selected: <Gender>{row.selectedGender},

--- a/lib/presentation/widgets/match_history_widgets.dart
+++ b/lib/presentation/widgets/match_history_widgets.dart
@@ -990,14 +990,18 @@ class _MatchSettingsDialogState extends State<MatchSettingsDialog> {
       children: [
         Row(mainAxisAlignment: MainAxisAlignment.center, children: [
           _CompactBadge(
-              label:
-                  '男性: ${pool.activeMales.length} 名 (${maleAvg.toStringAsFixed(1)}回/人)',
-              color: Colors.blue.shade700),
+            icon: Icons.male,
+            label:
+                '${pool.activeMales.length} 名 (${maleAvg.toStringAsFixed(1)}回/人)',
+            color: Colors.blue.shade700,
+          ),
           const SizedBox(width: 6),
           _CompactBadge(
-              label:
-                  '女性: ${pool.activeFemales.length} 名 (${femaleAvg.toStringAsFixed(1)}回/人)',
-              color: Colors.pink.shade600),
+            icon: Icons.female,
+            label:
+                '${pool.activeFemales.length} 名 (${femaleAvg.toStringAsFixed(1)}回/人)',
+            color: Colors.pink.shade600,
+          ),
         ]),
       ],
     );
@@ -1209,10 +1213,15 @@ class _MatchTypeSelector extends StatelessWidget {
 }
 
 class _CompactBadge extends StatelessWidget {
+  final IconData icon;
   final String label;
   final Color color;
 
-  const _CompactBadge({required this.label, required this.color});
+  const _CompactBadge({
+    required this.icon,
+    required this.label,
+    required this.color,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -1223,9 +1232,17 @@ class _CompactBadge extends StatelessWidget {
         borderRadius: BorderRadius.circular(20),
         border: Border.all(color: color.withValues(alpha: 0.5)),
       ),
-      child: Text(label,
-          style: TextStyle(
-              color: color, fontSize: 11)),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: color),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: TextStyle(color: color, fontSize: 11),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
### Motivation
- 参加メンバ設定ダイアログと一括設定の性別セグメントが横幅を取っていたため、表示をアイコン中心にしてレイアウトの幅を削減しつつ意味は保持するためにツールチップを追加しました。

### Description
- `lib/presentation/screens/player_list_screen.dart` の `SegmentedButton<Gender>` において、各 `ButtonSegment` から `label: Text('男性')` / `label: Text('女性')` を削除し、代わりに `tooltip: '男性'` / `tooltip: '女性'` を追加してアイコンのみの表示に変更しました（メンバ編集ダイアログと一括入力行の両箇所）。

### Testing
- 実行した自動チェックは `dart format` と `flutter --version` のコマンド実行で、どちらも実行環境に SDK が無いため失敗しました（`dart` / `flutter` コマンド未検出）；その他の自動テストスイートは実行していません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7afd5117083278d5d508c45c6149c)