### PR TITLE
Reset build number when a new version tag is built

### DIFF
--- a/.github/workflows/deploy_firebase_hosting.yml
+++ b/.github/workflows/deploy_firebase_hosting.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.vars.outputs.VERSION }}
+      build_number: ${{ steps.vars.outputs.BUILD_NUMBER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,9 +31,25 @@ jobs:
         id: vars
         run: |
           # 最新のタグ (v1.1.0等) を取得。タグがない場合は 0.0.0 を使用
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/v//' || echo "0.0.0")
+          RAW_LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+          LATEST_TAG=${RAW_LATEST_TAG#v}
+          if [ -z "$LATEST_TAG" ]; then
+            LATEST_TAG="0.0.0"
+          fi
+
+          # タグビルドは常に 0、ブランチビルドは直近タグからのコミット数を採用
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            BUILD_NUMBER=0
+          elif [ -n "$RAW_LATEST_TAG" ]; then
+            BUILD_NUMBER=$(git rev-list --count "${RAW_LATEST_TAG}..HEAD")
+          else
+            BUILD_NUMBER=$(git rev-list --count HEAD)
+          fi
+
           echo "VERSION=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "Using version: $LATEST_TAG"
+          echo "Using build number: $BUILD_NUMBER"
 
   deploy-web:
     needs: version
@@ -60,7 +77,7 @@ jobs:
           BUILD_DATE=$(date +'%Y/%m/%d')
           flutter build web --release \
             --build-name=${{ needs.version.outputs.version }} \
-            --build-number=${{ github.run_number }} \
+            --build-number=${{ needs.version.outputs.build_number }} \
             --dart-define=BUILD_DATE=$BUILD_DATE
 
       - name: Authenticate to Google Cloud
@@ -97,7 +114,7 @@ jobs:
           $BUILD_DATE = Get-Date -Format "yyyy/MM/dd"
           flutter build windows --release `
             --build-name=${{ needs.version.outputs.version }} `
-            --build-number=${{ github.run_number }} `
+            --build-number=${{ needs.version.outputs.build_number }} `
             --dart-define=BUILD_DATE=$BUILD_DATE
 
       - name: Upload artifact


### PR DESCRIPTION
### Motivation
- Ensure build numbers restart at `0` when a new version tag (e.g. `v1.2.0`) is built so released versions get a fresh build counter.
- Provide a single source of truth for build numbering that both web and Windows builds consume.

### Description
- Added a `build_number` output to the `version` job in `.github/workflows/deploy_firebase_hosting.yml` and compute it there. 
- Compute `BUILD_NUMBER` as `0` when the workflow runs for a tag matching `refs/tags/v*`, and otherwise compute it with `git rev-list --count` from the latest tag (or total commits if no tag exists). 
- Emit both `VERSION` and `BUILD_NUMBER` via `GITHUB_OUTPUT` for downstream jobs. 
- Switched `--build-number` in both the web and Windows `flutter build` steps from `github.run_number` to `needs.version.outputs.build_number`.

### Testing
- Verified the updated workflow file can be parsed as YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy_firebase_hosting.yml'); puts 'YAML OK'"` which succeeded. 
- Attempted a Python YAML load check but the environment lacked `PyYAML`, so the Python-based validation was skipped due to missing `PyYAML`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1e797ad0c8327bd5f8c26800f34cb)