### PR TITLE
Add DB table migration for shuttle_usage and improve save/error handling in ShuttleCalculation

### DIFF
--- a/lib/infrastructure/sqlite/sqlite_shuttle_usage_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_shuttle_usage_repository.dart
@@ -8,9 +8,38 @@ class SqliteShuttleUsageRepository implements ShuttleUsageRepository {
   final DatabaseHelper _dbHelper = DatabaseHelper();
   static const String _tableName = 'shuttle_usage';
 
+  Future<void> _ensureTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS $_tableName(
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        date TEXT,
+        total_shuttles INTEGER,
+        match_counts TEXT
+      )
+    ''');
+
+    final columns = await db.rawQuery('PRAGMA table_info($_tableName)');
+    final columnNames = columns
+        .map((c) => (c['name'] as String?) ?? '')
+        .where((name) => name.isNotEmpty)
+        .toSet();
+
+    if (!columnNames.contains('date')) {
+      await db.execute('ALTER TABLE $_tableName ADD COLUMN date TEXT');
+    }
+    if (!columnNames.contains('total_shuttles')) {
+      await db
+          .execute('ALTER TABLE $_tableName ADD COLUMN total_shuttles INTEGER');
+    }
+    if (!columnNames.contains('match_counts')) {
+      await db.execute('ALTER TABLE $_tableName ADD COLUMN match_counts TEXT');
+    }
+  }
+
   @override
   Future<void> save(ShuttleUsageRecord record) async {
     final db = await _dbHelper.database;
+    await _ensureTable(db);
     await db.insert(
       _tableName,
       record.toJson(),
@@ -21,6 +50,7 @@ class SqliteShuttleUsageRepository implements ShuttleUsageRepository {
   @override
   Future<List<ShuttleUsageRecord>> getAll() async {
     final db = await _dbHelper.database;
+    await _ensureTable(db);
     final List<Map<String, dynamic>> maps =
         await db.query(_tableName, orderBy: 'date DESC');
 
@@ -30,6 +60,7 @@ class SqliteShuttleUsageRepository implements ShuttleUsageRepository {
   @override
   Future<void> delete(int id) async {
     final db = await _dbHelper.database;
+    await _ensureTable(db);
     await db.delete(_tableName, where: 'id = ?', whereArgs: [id]);
   }
 }

--- a/lib/presentation/screens/shuttle_calculation_screen.dart
+++ b/lib/presentation/screens/shuttle_calculation_screen.dart
@@ -94,7 +94,7 @@ class ShuttleCalculationPageState extends State<ShuttleCalculationScreen> {
     _persistState();
   }
 
-  Future<void> _saveRecord() async {
+  Future<bool> _saveRecord() async {
     final sessions = widget.sessionNotifier.sessions;
     final Map<MatchType, int> typeCounts = {};
     for (var s in sessions) {
@@ -111,19 +111,28 @@ class ShuttleCalculationPageState extends State<ShuttleCalculationScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('シャトルの使用数が0です')),
       );
-      return;
+      return false;
     }
 
-    await widget.shuttleRepository.save(ShuttleUsageRecord(
-      date: _selectedDate,
-      totalShuttles: totalShuttles,
-      matchTypeCounts: typeCounts,
-    ));
+    try {
+      await widget.shuttleRepository.save(ShuttleUsageRecord(
+        date: _selectedDate,
+        totalShuttles: totalShuttles,
+        matchTypeCounts: typeCounts,
+      ));
+    } catch (_) {
+      if (!mounted) return false;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('保存に失敗しました。もう一度お試しください')),
+      );
+      return false;
+    }
 
-    if (!mounted) return;
+    if (!mounted) return true;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('消費記録を保存しました')),
     );
+    return true;
   }
 
   void _showHistory() {
@@ -665,8 +674,10 @@ class ShuttleCalculationPageState extends State<ShuttleCalculationScreen> {
           });
         },
         onConfirm: () async {
-          await _saveRecord();
-          if (mounted) Navigator.pop(context);
+          final saved = await _saveRecord();
+          if (saved && mounted) {
+            Navigator.pop(context);
+          }
         },
       ),
     );


### PR DESCRIPTION
### Motivation
- Ensure the `shuttle_usage` table exists and is migrated safely when the app opens so older databases won't fail when reading or writing records. 
- Improve the save flow in the shuttle calculation UI to surface errors and avoid dismissing the settlement sheet when persisting fails.

### Description
- Add a private `_ensureTable(Database db)` to `SqliteShuttleUsageRepository` that creates `shuttle_usage` if missing and adds missing columns via `PRAGMA table_info` + `ALTER TABLE` checks. 
- Call `_ensureTable` at the start of `save`, `getAll`, and `delete` in `sqlite_shuttle_usage_repository.dart` to guarantee schema availability before operations. 
- Change `_saveRecord` in `shuttle_calculation_screen.dart` to return a `bool`, wrap the repository `save` call in a `try/catch`, show a failure `SnackBar` on exceptions, and return success/failure accordingly. 
- Use the returned boolean to only dismiss the settlement sheet when the save succeeded and show a success `SnackBar` on success.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4bd7048e883279bc0be82b71f1a6d)