### PR TITLE
Add batch player repository APIs and switch notifier bulk flows

### DIFF
--- a/lib/domain/repository/player_repository/in_memory_repository.dart
+++ b/lib/domain/repository/player_repository/in_memory_repository.dart
@@ -18,6 +18,19 @@ class InMemoryPlayerRepository implements PlayerRepository {
   }
 
   @override
+  Future<void> addAll(List<Player> players) async {
+    if (players.isEmpty) return;
+
+    final existingById = {for (final player in _players) player.id: player};
+    for (final player in players) {
+      existingById[player.id] = player;
+    }
+    _players
+      ..clear()
+      ..addAll(existingById.values);
+  }
+
+  @override
   Future<void> update(Player player) async {
     final index = _players.indexWhere((p) => p.id == player.id);
     if (index != -1) {
@@ -26,7 +39,20 @@ class InMemoryPlayerRepository implements PlayerRepository {
   }
 
   @override
+  Future<void> updateAll(List<Player> players) async {
+    await addAll(players);
+  }
+
+  @override
   Future<void> remove(String id) async {
     _players.removeWhere((p) => p.id == id);
+  }
+
+  @override
+  Future<void> removeAll(List<String> ids) async {
+    if (ids.isEmpty) return;
+
+    final idSet = ids.toSet();
+    _players.removeWhere((p) => idSet.contains(p.id));
   }
 }

--- a/lib/domain/repository/player_repository/player_repository.dart
+++ b/lib/domain/repository/player_repository/player_repository.dart
@@ -7,7 +7,13 @@ abstract class PlayerRepository {
 
   Future<void> add(Player player);
 
+  Future<void> addAll(List<Player> players);
+
   Future<void> update(Player player);
 
+  Future<void> updateAll(List<Player> players);
+
   Future<void> remove(String id);
+
+  Future<void> removeAll(List<String> ids);
 }

--- a/lib/infrastructure/shared_preferences/shared_preferences_player_repository.dart
+++ b/lib/infrastructure/shared_preferences/shared_preferences_player_repository.dart
@@ -25,6 +25,18 @@ class SharedPreferencesPlayerRepository implements PlayerRepository {
   }
 
   @override
+  Future<void> addAll(List<Player> players) async {
+    if (players.isEmpty) return;
+
+    final currentPlayers = await getAll();
+    final playerById = {for (final p in currentPlayers) p.id: p};
+    for (final player in players) {
+      playerById[player.id] = player;
+    }
+    await _saveAll(playerById.values.toList());
+  }
+
+  @override
   Future<List<Player>> getActive() async {
     final players = await getAll();
     return players.where((p) => p.isActive).toList();
@@ -56,6 +68,21 @@ class SharedPreferencesPlayerRepository implements PlayerRepository {
   @override
   Future<void> update(Player player) async {
     await add(player);
+  }
+
+  @override
+  Future<void> updateAll(List<Player> players) async {
+    await addAll(players);
+  }
+
+  @override
+  Future<void> removeAll(List<String> ids) async {
+    if (ids.isEmpty) return;
+
+    final idSet = ids.toSet();
+    final players = await getAll();
+    players.removeWhere((player) => idSet.contains(player.id));
+    await _saveAll(players);
   }
 
   Future<void> _saveAll(List<Player> players) async {

--- a/lib/infrastructure/sqlite/sqlite_player_repository.dart
+++ b/lib/infrastructure/sqlite/sqlite_player_repository.dart
@@ -37,6 +37,24 @@ class SqlitePlayerRepository implements PlayerRepository {
   }
 
   @override
+  Future<void> addAll(List<Player> players) async {
+    if (players.isEmpty) return;
+
+    final db = await _dbHelper.database;
+    await db.transaction((txn) async {
+      final batch = txn.batch();
+      for (final player in players) {
+        batch.insert(
+          _tableName,
+          player.toJson(),
+          conflictAlgorithm: ConflictAlgorithm.replace,
+        );
+      }
+      await batch.commit(noResult: true);
+    });
+  }
+
+  @override
   Future<void> update(Player player) async {
     final db = await _dbHelper.database;
     await db.update(
@@ -48,6 +66,25 @@ class SqlitePlayerRepository implements PlayerRepository {
   }
 
   @override
+  Future<void> updateAll(List<Player> players) async {
+    if (players.isEmpty) return;
+
+    final db = await _dbHelper.database;
+    await db.transaction((txn) async {
+      final batch = txn.batch();
+      for (final player in players) {
+        batch.update(
+          _tableName,
+          player.toJson(),
+          where: 'id = ?',
+          whereArgs: [player.id],
+        );
+      }
+      await batch.commit(noResult: true);
+    });
+  }
+
+  @override
   Future<void> remove(String id) async {
     final db = await _dbHelper.database;
     await db.delete(
@@ -55,5 +92,23 @@ class SqlitePlayerRepository implements PlayerRepository {
       where: 'id = ?',
       whereArgs: [id],
     );
+  }
+
+  @override
+  Future<void> removeAll(List<String> ids) async {
+    if (ids.isEmpty) return;
+
+    final db = await _dbHelper.database;
+    await db.transaction((txn) async {
+      final batch = txn.batch();
+      for (final id in ids) {
+        batch.delete(
+          _tableName,
+          where: 'id = ?',
+          whereArgs: [id],
+        );
+      }
+      await batch.commit(noResult: true);
+    });
   }
 }

--- a/lib/presentation/notifiers/player_notifier.dart
+++ b/lib/presentation/notifiers/player_notifier.dart
@@ -46,18 +46,22 @@ class PlayerNotifier extends ChangeNotifier {
 
   Future<(int added, int skipped)> addPlayersBulk(List<Player> players) async {
     await _refresh();
+    final existingIds = _players.map((p) => p.id).toSet();
     int added = 0;
     int skipped = 0;
+    final playersToAdd = <Player>[];
 
     for (final player in players) {
-      if (_players.any((p) => p.id == player.id) || _exists(player)) {
+      if (existingIds.contains(player.id) || _exists(player)) {
         skipped++;
         continue;
       }
-      await repository.add(player);
+      playersToAdd.add(player);
+      existingIds.add(player.id);
       added++;
     }
 
+    await repository.addAll(playersToAdd);
     await _refresh();
     return (added, skipped);
   }
@@ -74,13 +78,15 @@ class PlayerNotifier extends ChangeNotifier {
   Future<int> setActiveBulk(List<String> ids, bool isActive) async {
     final uniqueIds = ids.toSet();
     int updated = 0;
+    final playersToUpdate = <Player>[];
     for (final player in _players) {
       if (!uniqueIds.contains(player.id) || player.isActive == isActive) {
         continue;
       }
-      await repository.update(player.copyWith(isActive: isActive));
+      playersToUpdate.add(player.copyWith(isActive: isActive));
       updated++;
     }
+    await repository.updateAll(playersToUpdate);
     await _refresh();
     return updated;
   }
@@ -91,19 +97,14 @@ class PlayerNotifier extends ChangeNotifier {
   }
 
   Future<int> removePlayersBulk(List<String> ids) async {
-    int removed = 0;
-    for (final id in ids.toSet()) {
-      await repository.remove(id);
-      removed++;
-    }
+    final uniqueIds = ids.toSet();
+    await repository.removeAll(uniqueIds.toList());
     await _refresh();
-    return removed;
+    return uniqueIds.length;
   }
 
   Future<void> _updatePlayers(List<Player> updatedList) async {
-    for (var p in updatedList) {
-      await repository.update(p);
-    }
+    await repository.updateAll(updatedList);
     await _refresh();
   }
 
@@ -170,22 +171,25 @@ class PlayerNotifier extends ChangeNotifier {
 
   Future<String> _applyImportedList(List<Player> list) async {
     await _refresh();
+    final existingIds = _players.map((p) => p.id).toSet();
     int count = 0;
     int skipCount = 0;
-    for (var player in list) {
-      final existingById = _players.any((p) => p.id == player.id);
-      if (existingById) {
-        await repository.update(player);
+    final playersToUpsert = <Player>[];
+    for (final player in list) {
+      if (existingIds.contains(player.id)) {
+        playersToUpsert.add(player);
         count++;
         continue;
       }
-      if (_exists(player)) {
+      if (_exists(player) || playersToUpsert.contains(player)) {
         skipCount++;
         continue;
       }
-      await repository.add(player);
+      playersToUpsert.add(player);
+      existingIds.add(player.id);
       count++;
     }
+    await repository.addAll(playersToUpsert);
     await _refresh();
     String msg = '$count名のメンバーをインポートしました';
     if (skipCount > 0) msg += ' ($skipCount名は重複のためスキップ)';

--- a/test/domain/services/match_making_service_test.dart
+++ b/test/domain/services/match_making_service_test.dart
@@ -41,6 +41,11 @@ class FakePlayerRepository implements PlayerRepository {
   Future<void> add(Player player) async => players.add(player);
 
   @override
+  Future<void> addAll(List<Player> players) async {
+    this.players.addAll(players);
+  }
+
+  @override
   Future<List<Player>> getActive() async =>
       players.where((p) => p.isActive).toList(growable: false);
 
@@ -51,10 +56,23 @@ class FakePlayerRepository implements PlayerRepository {
   Future<void> remove(String id) async => players.removeWhere((p) => p.id == id);
 
   @override
+  Future<void> removeAll(List<String> ids) async {
+    final idSet = ids.toSet();
+    players.removeWhere((p) => idSet.contains(p.id));
+  }
+
+  @override
   Future<void> update(Player player) async {
     final i = players.indexWhere((p) => p.id == player.id);
     if (i != -1) {
       players[i] = player;
+    }
+  }
+
+  @override
+  Future<void> updateAll(List<Player> players) async {
+    for (final player in players) {
+      await update(player);
     }
   }
 }

--- a/test/presentation/notifiers/player_notifier_test.dart
+++ b/test/presentation/notifiers/player_notifier_test.dart
@@ -20,14 +20,34 @@ class MockPlayerRepository implements PlayerRepository {
   Future<void> add(Player player) async => _players.add(player);
 
   @override
+  Future<void> addAll(List<Player> players) async {
+    for (final player in players) {
+      await add(player);
+    }
+  }
+
+  @override
   Future<void> remove(String id) async =>
       _players.removeWhere((p) => p.id == id);
+
+  @override
+  Future<void> removeAll(List<String> ids) async {
+    final idSet = ids.toSet();
+    _players.removeWhere((p) => idSet.contains(p.id));
+  }
 
   @override
   Future<void> update(Player player) async {
     final index = _players.indexWhere((p) => p.id == player.id);
     if (index != -1) {
       _players[index] = player;
+    }
+  }
+
+  @override
+  Future<void> updateAll(List<Player> players) async {
+    for (final player in players) {
+      await update(player);
     }
   }
 }

--- a/test/session_notifier_test.dart
+++ b/test/session_notifier_test.dart
@@ -63,13 +63,31 @@ class MockPlayerRepository implements PlayerRepository {
   Future<void> add(Player player) async => players.add(player);
 
   @override
+  Future<void> addAll(List<Player> players) async {
+    this.players.addAll(players);
+  }
+
+  @override
   Future<void> remove(String id) async =>
       players.removeWhere((p) => p.id == id);
+
+  @override
+  Future<void> removeAll(List<String> ids) async {
+    final idSet = ids.toSet();
+    players.removeWhere((p) => idSet.contains(p.id));
+  }
 
   @override
   Future<void> update(Player player) async {
     final index = players.indexWhere((p) => p.id == player.id);
     if (index != -1) players[index] = player;
+  }
+
+  @override
+  Future<void> updateAll(List<Player> players) async {
+    for (final player in players) {
+      await update(player);
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation
- `PlayerRepository` にバッチ操作を追加して複数レコードの永続化をループで逐次実行する非効率な処理を置き換え、パフォーマンスと一貫性を改善するため。 
- SQLite 実装ではトランザクション／バッチを使い原子性を確保し、SharedPreferences 実装では読み込み→一括更新→一括保存の形にして無駄な I/O を削減するため。 

### Description
- インターフェース `PlayerRepository` に `addAll`, `updateAll`, `removeAll` を追加した。 
- `SqlitePlayerRepository` に `addAll` / `updateAll` / `removeAll` を実装し、`db.transaction(...)` と `txn.batch()` を使って一括 INSERT/UPDATE/DELETE を行うようにした。 
- `SharedPreferencesPlayerRepository` で一括追加／更新／削除を、読み込み→ID マップで統合→`_saveAll` の一回書き込みで実装した。 
- `InMemoryPlayerRepository` をバッチ API に対応させた。 
- `PlayerNotifier` のバルク操作（`addPlayersBulk` / `setActiveBulk` / `removePlayersBulk` / `_updatePlayers` / `_applyImportedList` 等）をループで個別呼び出ししていた実装から、`repository.addAll` / `repository.updateAll` / `repository.removeAll` を使う形に置換した。 

### Testing
- `dart format` を試行したが `dart: command not found` のため実行できなかった。 
- `flutter --version` を試行したが `flutter: command not found` のため実行できなかった。 
- `git diff --check && git status --short` を実行して差分に問題がないことを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d8f16ff88327aedcab27f60a6d74)