### PR TITLE
Offload match generation to Isolate with DTO serialization and timeline tracing

### DIFF
--- a/lib/domain/services/match_making_service.dart
+++ b/lib/domain/services/match_making_service.dart
@@ -1,9 +1,14 @@
+import 'dart:developer' as dev;
+import 'dart:isolate';
+
 import 'package:game_member_generator/domain/entities/player.dart';
 import 'package:game_member_generator/domain/entities/player_stats_pool.dart';
 
 import '../algorithm/match_algorithm.dart';
 import '../entities/game.dart';
 import '../entities/match_type.dart';
+import '../entities/player_stats.dart';
+import '../entities/player_with_stats.dart';
 import '../repository/player_repository/player_repository.dart';
 
 class MatchGenerationResult {
@@ -44,10 +49,52 @@ class MatchMakingService {
     final activeIds = activePlayers.map((player) => player.id).toSet();
     final activePool = playerStats.filterByIds(activeIds);
 
-    final games = algorithm.generateMatches(
+    final matchDto = _MatchGenerationInputDto.fromDomain(
       matchTypes: matchTypes,
-      playerPool: activePool,
+      playerStats: activePool,
     );
+
+    final startAt = DateTime.now();
+    final timelineTask = dev.TimelineTask();
+    timelineTask.start(
+      'matchmaking_search',
+      arguments: {'startedAt': startAt.toIso8601String()},
+    );
+    dev.Timeline.instantSync(
+      'matchmaking_search_start',
+      arguments: {'startedAt': startAt.toIso8601String()},
+    );
+
+    late final List<_GameDto> gameDtos;
+    try {
+      gameDtos = await Isolate.run(
+        () {
+          final domainMatchTypes = matchDto.matchTypeIndexes
+              .map((index) => MatchType.values[index])
+              .toList(growable: false);
+
+          final domainPool = matchDto.toDomainPool();
+          final generatedGames = algorithm.generateMatches(
+            matchTypes: domainMatchTypes,
+            playerPool: domainPool,
+          );
+
+          return generatedGames
+              .map((game) => _GameDto.fromDomain(game))
+              .toList(growable: false);
+        },
+        debugName: 'matchmaking_search_isolate',
+      );
+    } finally {
+      final endAt = DateTime.now();
+      dev.Timeline.instantSync(
+        'matchmaking_search_end',
+        arguments: {'endedAt': endAt.toIso8601String()},
+      );
+      timelineTask.finish(arguments: {'endedAt': endAt.toIso8601String()});
+    }
+
+    final games = gameDtos.map((dto) => dto.toDomain()).toList(growable: false);
 
     final playingPlayerIds = games
         .expand(
@@ -68,5 +115,128 @@ class MatchMakingService {
       games: games,
       restingPlayers: restingPlayers,
     );
+  }
+}
+
+class _MatchGenerationInputDto {
+  final List<int> matchTypeIndexes;
+  final List<Map<String, Object?>> players;
+  final List<List<String>> previousMaleSelections;
+  final List<List<String>> previousFemaleSelections;
+
+  const _MatchGenerationInputDto({
+    required this.matchTypeIndexes,
+    required this.players,
+    required this.previousMaleSelections,
+    required this.previousFemaleSelections,
+  });
+
+  factory _MatchGenerationInputDto.fromDomain({
+    required List<MatchType> matchTypes,
+    required PlayerStatsPool playerStats,
+  }) {
+    return _MatchGenerationInputDto(
+      matchTypeIndexes: matchTypes.map((type) => type.index).toList(growable: false),
+      players: playerStats.all
+          .map(
+            (playerWithStats) => {
+              'player': playerWithStats.player.toJson(),
+              'stats': _playerStatsToDto(playerWithStats.stats),
+            },
+          )
+          .toList(growable: false),
+      previousMaleSelections: playerStats.previousMaleSelections
+          .map((selection) => selection.toList(growable: false))
+          .toList(growable: false),
+      previousFemaleSelections: playerStats.previousFemaleSelections
+          .map((selection) => selection.toList(growable: false))
+          .toList(growable: false),
+    );
+  }
+
+  PlayerStatsPool toDomainPool() {
+    return PlayerStatsPool(
+      players
+          .map(
+            (entry) => PlayerWithStats(
+              player: Player.fromJson(entry['player']! as Map<String, dynamic>),
+              stats: _playerStatsFromDto(entry['stats']! as Map<String, Object?>),
+            ),
+          )
+          .toList(growable: false),
+      previousMaleSelections: previousMaleSelections
+          .map((selection) => selection.toSet())
+          .toList(growable: false),
+      previousFemaleSelections: previousFemaleSelections
+          .map((selection) => selection.toSet())
+          .toList(growable: false),
+    );
+  }
+
+  static Map<String, Object?> _playerStatsToDto(PlayerStats stats) {
+    return {
+      'totalMatches': stats.totalMatches,
+      'totalRests': stats.totalRests,
+      'typeCounts': {
+        for (final entry in stats.typeCounts.entries) entry.key.index.toString(): entry.value,
+      },
+      'partnerCounts': stats.partnerCounts,
+      'opponentCounts': stats.opponentCounts,
+      'restTogetherCounts': stats.restTogetherCounts,
+      'restedLastTime': stats.restedLastTime,
+      'sessionsSinceLastRest': stats.sessionsSinceLastRest,
+      'consecutiveRests': stats.consecutiveRests,
+      'lastMatchType': stats.lastMatchType?.index,
+    };
+  }
+
+  static PlayerStats _playerStatsFromDto(Map<String, Object?> dto) {
+    final typeCountsDto = dto['typeCounts']! as Map<String, Object?>;
+    return PlayerStats(
+      totalMatches: dto['totalMatches']! as int,
+      totalRests: dto['totalRests']! as int,
+      typeCounts: {
+        for (final entry in typeCountsDto.entries)
+          MatchType.values[int.parse(entry.key)]: entry.value! as int,
+      },
+      partnerCounts: Map<String, int>.from(dto['partnerCounts']! as Map),
+      opponentCounts: Map<String, int>.from(dto['opponentCounts']! as Map),
+      restTogetherCounts: Map<String, int>.from(dto['restTogetherCounts']! as Map),
+      restedLastTime: dto['restedLastTime']! as bool,
+      sessionsSinceLastRest: dto['sessionsSinceLastRest']! as int,
+      consecutiveRests: dto['consecutiveRests']! as int,
+      lastMatchType: switch (dto['lastMatchType']) {
+        final int index => MatchType.values[index],
+        _ => null,
+      },
+    );
+  }
+}
+
+class _GameDto {
+  final int typeIndex;
+  final Map<String, dynamic> teamA;
+  final Map<String, dynamic> teamB;
+
+  const _GameDto({
+    required this.typeIndex,
+    required this.teamA,
+    required this.teamB,
+  });
+
+  factory _GameDto.fromDomain(Game game) {
+    return _GameDto(
+      typeIndex: game.type.index,
+      teamA: game.teamA.toJson(),
+      teamB: game.teamB.toJson(),
+    );
+  }
+
+  Game toDomain() {
+    return Game.fromJson({
+      'type': typeIndex,
+      'teamA': teamA,
+      'teamB': teamB,
+    });
   }
 }

--- a/test/domain/services/match_making_service_test.dart
+++ b/test/domain/services/match_making_service_test.dart
@@ -12,21 +12,20 @@ import 'package:game_member_generator/domain/repository/player_repository/player
 import 'package:game_member_generator/domain/services/match_making_service.dart';
 
 class RecordingAlgorithm implements MatchAlgorithm {
-  List<String> receivedIds = [];
-
   @override
   List<Game> generateMatches({
     required List<MatchType> matchTypes,
     required PlayerStatsPool playerPool,
   }) {
-    receivedIds = playerPool.all.map((p) => p.player.id).toList()..sort();
+    final players = playerPool.all.map((p) => p.player).toList()
+      ..sort((a, b) => a.id.compareTo(b.id));
 
-    final players = playerPool.all.map((p) => p.player).toList();
+    final selected = players.sublist(players.length - 4);
     return [
       Game(
         matchTypes.first,
-        Team(players[0], players[1]),
-        Team(players[2], players[3]),
+        Team(selected[0], selected[1]),
+        Team(selected[2], selected[3]),
       ),
     ];
   }
@@ -124,9 +123,16 @@ void main() {
         playerStats: playerStats,
       );
 
-      expect(algorithm.receivedIds, ['1', '2', '3', '4', '5']);
+      final playingIds = [
+        result.games.first.teamA.player1.id,
+        result.games.first.teamA.player2.id,
+        result.games.first.teamB.player1.id,
+        result.games.first.teamB.player2.id,
+      ]..sort();
+
       expect(result.games, hasLength(1));
-      expect(result.restingPlayers.map((p) => p.id), ['5']);
+      expect(playingIds, ['2', '3', '4', '5']);
+      expect(result.restingPlayers.map((p) => p.id), ['1']);
     });
   });
 }


### PR DESCRIPTION
### Motivation
- Prevent the heavy match-generation search from blocking the main isolate by running it in a background isolate via `Isolate.run`.
- Ensure data passed to/from the isolate is safely serializable by converting domain inputs/outputs to compact DTOs.
- Add timing markers so search start/end can be inspected in profiling tools and compared against frame timing using `dart:developer` `Timeline`.

### Description
- Moved the `algorithm.generateMatches(...)` invocation into an `Isolate.run` closure and added a `debugName` for clarity in traces.
- Introduced `_MatchGenerationInputDto` to serialize `matchTypes` (as indexes), `PlayerStatsPool` (players + `PlayerStats` DTO) and previous selections, and rehydrate them inside the isolate to `PlayerStatsPool`/domain objects.
- Added `_GameDto` to return generated games from the isolate and convert them back to `Game` via `Game.fromJson` after the isolate completes.
- Wrapped the isolate execution with `dev.TimelineTask()` and `dev.Timeline.instantSync` start/end events including `startedAt`/`endedAt` ISO timestamps to allow measuring the search duration in tooling.

### Testing
- Attempted to run `dart format` and `dart analyze` but static checks could not be executed because `dart` is not available in the current environment.
- Verified the modified file `lib/domain/services/match_making_service.dart` contains the isolate and DTO implementations and builds conceptually from the code changes (no runtime tests executed).
- No automated unit/integration tests were run in this environment due to missing Dart tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae41a18308327866ab3039e84a078)