### PR TITLE
CI: build Windows artifact when PRs are merged

### DIFF
--- a/.github/workflows/release_windows.yaml
+++ b/.github/workflows/release_windows.yaml
@@ -4,12 +4,17 @@ on:
   push:
     tags:
       - "v*"
+  pull_request:
+    types: [closed]
+    branches:
+      - master
 
 permissions:
   contents: write
 
 jobs:
   build:
+    if: startsWith(github.ref, 'refs/tags/') || github.event.pull_request.merged == true
     runs-on: windows-latest
 
     steps:
@@ -34,15 +39,25 @@ jobs:
       - name: Build Windows
         run: flutter build windows --release
 
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: game_member_generator_windows
+          path: build/windows/x64/runner/Release
+          overwrite: true
+
       - name: Prepare release folder
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           mkdir release
           xcopy build\windows\x64\runner\Release\* release\ /E /I
 
       - name: Zip build
+        if: startsWith(github.ref, 'refs/tags/')
         run: Compress-Archive -Path release\* -DestinationPath game_member_generator_windows.zip
 
       - name: Create Release
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
           name: Release ${{ github.ref_name }}


### PR DESCRIPTION
### Motivation
- Make Windows build artifacts available immediately after a PR is completed by producing/updating artifacts on PR merge in addition to tag-based releases.
- Preserve existing behavior for publishing ZIPs and GitHub Releases only on version tag pushes.

### Description
- Added `pull_request` (type `closed`) targeting `master` to the workflow trigger so merges can start the workflow in addition to tag pushes.
- Added a job-level condition `if: startsWith(github.ref, 'refs/tags/') || github.event.pull_request.merged == true` so the job runs only for tag pushes or actually merged PR closures.
- Uploaded the Windows build output with `actions/upload-artifact@v4` under the name `game_member_generator_windows` and `overwrite: true`, and kept ZIP/Release steps gated by `if: startsWith(github.ref, 'refs/tags/')`.

### Testing
- Ran `git diff -- .github/workflows/release_windows.yaml` to verify the workflow changes, which returned the expected diff (succeeded).
- Inspected the updated workflow file with `nl -ba .github/workflows/release_windows.yaml` to confirm the new trigger, job condition, artifact upload, and tag-only release steps (succeeded).
- Checked repository status with `git status --short` and `git branch --show-current` to ensure the working tree and branch context were as expected (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae561c4f88327bab75a8f460214a8)