### PR TITLE
Add quick player edit menu, explicit swap action, and one-time coach mark

### DIFF
--- a/lib/presentation/screens/match_history_screen.dart
+++ b/lib/presentation/screens/match_history_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../domain/entities/court_settings.dart';
 import '../../domain/entities/player.dart';
@@ -33,8 +34,11 @@ class MatchHistoryScreen extends StatefulWidget {
 }
 
 class _MatchHistoryScreenState extends State<MatchHistoryScreen> {
+  static const _coachMarkKey = 'coach_mark_swap_mode_v1_shown';
+
   int? _currentIndex;
   Player? _selectedPlayer;
+  bool _coachMarkCheckStarted = false;
 
   late final SessionNotifier _sessionNotifier;
   bool _providersBound = false;
@@ -44,7 +48,46 @@ class _MatchHistoryScreenState extends State<MatchHistoryScreen> {
     super.didChangeDependencies();
     if (_providersBound) return;
     _sessionNotifier = AppScope.of(context).sessionNotifier;
+    _showCoachMarkIfNeeded();
     _providersBound = true;
+  }
+
+  Future<void> _showCoachMarkIfNeeded() async {
+    if (_coachMarkCheckStarted) return;
+    _coachMarkCheckStarted = true;
+
+    final prefs = await SharedPreferences.getInstance();
+    final hasShown = prefs.getBool(_coachMarkKey) ?? false;
+    if (hasShown || !mounted) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+      await showDialog<void>(
+        context: context,
+        builder: (dialogContext) => AlertDialog(
+          title: const Text('はじめての操作ガイド',
+              style: TextStyle(fontWeight: FontWeight.w900)),
+          content: const Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('・「選手を入れ替える」ボタンで入れ替えモードを開始できます。'),
+              SizedBox(height: 8),
+              Text('・選手を長押しすると、その選手を起点にすぐ入れ替えできます。'),
+              SizedBox(height: 8),
+              Text('・入れ替え中は、交換したい相手をタップしてください。'),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      );
+      await prefs.setBool(_coachMarkKey, true);
+    });
   }
 
   void _updateIndexSafely({int? targetIndex}) {
@@ -223,7 +266,11 @@ class _MatchHistoryScreenState extends State<MatchHistoryScreen> {
 
           return Column(
             children: [
-              _buildInstructionBanner(theme, _selectedPlayer != null),
+              _buildInstructionBanner(
+                theme,
+                _selectedPlayer != null,
+                session: session,
+              ),
               Expanded(
                 child: SingleChildScrollView(
                   physics: const AlwaysScrollableScrollPhysics(),
@@ -258,7 +305,11 @@ class _MatchHistoryScreenState extends State<MatchHistoryScreen> {
         },
       );
 
-  Widget _buildInstructionBanner(ThemeData theme, bool isSwapping) {
+  Widget _buildInstructionBanner(
+    ThemeData theme,
+    bool isSwapping, {
+    required Session session,
+  }) {
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -277,7 +328,9 @@ class _MatchHistoryScreenState extends State<MatchHistoryScreen> {
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              isSwapping ? '入れ替える相手をタップしてください' : '長押しで選手を入れ替えられます',
+              isSwapping
+                  ? '入れ替える相手をタップしてください'
+                  : '「選手を入れ替える」または長押しで開始できます',
               style: TextStyle(
                 fontSize: 11,
                 fontWeight: isSwapping ? FontWeight.bold : FontWeight.normal,
@@ -287,9 +340,60 @@ class _MatchHistoryScreenState extends State<MatchHistoryScreen> {
               ),
             ),
           ),
+          if (!isSwapping)
+            TextButton.icon(
+              onPressed: () => _showSwapSourceSelector(session),
+              icon: const Icon(Icons.swap_horiz, size: 16),
+              label: const Text('選手を入れ替える'),
+            )
+          else
+            TextButton(
+              onPressed: () => setState(() => _selectedPlayer = null),
+              child: const Text('終了'),
+            ),
         ],
       ),
     );
+  }
+
+  Future<void> _showSwapSourceSelector(Session session) async {
+    final players = <Player>[
+      ...session.games.expand((game) => [
+            game.teamA.player1,
+            game.teamA.player2,
+            game.teamB.player1,
+            game.teamB.player2,
+          ]),
+      ...session.restingPlayers,
+    ];
+    final uniquePlayers = <String, Player>{for (final p in players) p.id: p}.values
+        .toList()
+      ..sort((a, b) => a.yomigana.compareTo(b.yomigana));
+    if (uniquePlayers.isEmpty || !mounted) return;
+
+    final selected = await showModalBottomSheet<Player>(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: uniquePlayers.length,
+            itemBuilder: (context, index) {
+              final player = uniquePlayers[index];
+              return ListTile(
+                leading: const Icon(Icons.person_outline),
+                title: Text(player.name),
+                subtitle: Text(player.yomigana),
+                onTap: () => Navigator.pop(sheetContext, player),
+              );
+            },
+          ),
+        );
+      },
+    );
+    if (selected == null || !mounted) return;
+    setState(() => _selectedPlayer = selected);
   }
 
   Widget _buildFABs(Session? session, ColorScheme colorScheme) => Padding(

--- a/lib/presentation/screens/player_list_screen.dart
+++ b/lib/presentation/screens/player_list_screen.dart
@@ -498,7 +498,7 @@ class _PlayerListScreenState extends State<PlayerListScreen> {
           const SizedBox(width: 8),
           Expanded(
             child: Text(
-              'タップで本日の参加切替、長押しでメンバー情報の修正',
+              'タップで本日の参加切替、⋯ボタン/長押しでメンバー編集',
               style: TextStyle(
                   fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
             ),
@@ -743,10 +743,87 @@ class _PlayerListScreenState extends State<PlayerListScreen> {
           onLongPress: () {
             _showAddEditDialog(context, player: p.player);
           },
+          onOpenMenu: () => _showPlayerQuickMenu(context, p.player),
           showCheckbox: showCheckbox,
           showStats: showStats,
         );
       }).toList(),
+    );
+  }
+
+  void _showPlayerQuickMenu(BuildContext context, Player player) {
+    showModalBottomSheet(
+      context: context,
+      showDragHandle: true,
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.edit_outlined),
+                title: const Text('メンバー情報を編集'),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _showAddEditDialog(context, player: player);
+                },
+              ),
+              ListTile(
+                leading: Icon(
+                    player.isActive ? Icons.person_remove : Icons.person_add),
+                title: Text(
+                    player.isActive ? '本日の参加から外す' : '本日の参加に追加'),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _showActivateDeactivateDialog(context, player);
+                },
+              ),
+              ListTile(
+                leading: Icon(Icons.delete_outline,
+                    color: Theme.of(context).colorScheme.error),
+                title: Text(
+                  'メンバーを削除',
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _showDeleteConfirm(context, player);
+                },
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _showDeleteConfirm(BuildContext context, Player player) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text(
+          'メンバー削除',
+          style: TextStyle(fontWeight: FontWeight.w900),
+        ),
+        content: Text('「${player.name}」を削除しますか？'),
+        actions: [
+          AppActionButton(
+            label: 'キャンセル',
+            onPressed: () => Navigator.pop(dialogContext),
+            isPrimary: false,
+          ),
+          AppActionButton(
+            label: '削除',
+            onPressed: () {
+              _playerNotifier.removePlayer(player.id);
+              Navigator.pop(dialogContext);
+            },
+            isPrimary: true,
+            color: Theme.of(context).colorScheme.error,
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/presentation/widgets/player_list_widgets.dart
+++ b/lib/presentation/widgets/player_list_widgets.dart
@@ -69,6 +69,7 @@ class PlayerChip extends StatelessWidget {
   final PlayerWithStats playerWithStats;
   final VoidCallback onTap;
   final VoidCallback onLongPress;
+  final VoidCallback? onOpenMenu;
   final bool showCheckbox;
   final bool showStats;
 
@@ -77,6 +78,7 @@ class PlayerChip extends StatelessWidget {
     required this.playerWithStats,
     required this.onTap,
     required this.onLongPress,
+    this.onOpenMenu,
     this.showCheckbox = false,
     this.showStats = false,
   });
@@ -141,7 +143,11 @@ class PlayerChip extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      _PlayerChipHeader(player: player, token: token),
+                      _PlayerChipHeader(
+                        player: player,
+                        token: token,
+                        onOpenMenu: onOpenMenu,
+                      ),
                       if (showStats) ...[
                         const SizedBox(height: AppSpacing.xs + 2),
                         _PlayerChipStats(
@@ -167,10 +173,12 @@ class PlayerChip extends StatelessWidget {
 class _PlayerChipHeader extends StatelessWidget {
   final Player player;
   final _PlayerChipVisualToken token;
+  final VoidCallback? onOpenMenu;
 
   const _PlayerChipHeader({
     required this.player,
     required this.token,
+    this.onOpenMenu,
   });
 
   @override
@@ -199,6 +207,16 @@ class _PlayerChipHeader extends StatelessWidget {
           const SizedBox(width: AppSpacing.xs),
           Icon(Icons.coffee_outlined, size: 14, color: token.mustRestIconColor),
         ],
+        const SizedBox(width: AppSpacing.xs),
+        InkResponse(
+          onTap: onOpenMenu,
+          radius: 18,
+          child: Icon(
+            Icons.more_horiz,
+            size: 18,
+            color: token.nameColor.withValues(alpha: 0.75),
+          ),
+        ),
       ],
     );
   }


### PR DESCRIPTION
### Motivation
- ユーザーがプレイヤーの編集操作へ素早くアクセスできるようにプレイヤーチップにクイックアクションを追加するため。 
- 試合画面で長押しショートカットに加えて明示的に入れ替えモードを開始するUIを用意して導線を分かりやすくするため。 
- 新しい明示的操作を知らない初回ユーザー向けに軽量チュートリアル（coach mark）を一度だけ表示するため。 

### Description
- プレイヤーチップにオプションのコールバック `onOpenMenu` を追加し、ヘッダに `more_horiz` アイコンを表示してタップでクイックメニューを開けるようにした（編集／参加切替／削除の項目を含む）。
- メンバー一覧のヒント文言を `⋯ボタン/長押しでメンバー編集` に更新して新しい操作を案内するようにした。 
- 試合画面に一時的なチュートリアル表示を追加し、`SharedPreferences` のフラグ `coach_mark_swap_mode_v1_shown` で初回のみ表示するようにした。 
- 試合画面のインストラクションバナーに明示的な開始ボタン `選手を入れ替える` を追加し、押下時は選手選択のボトムシートを表示して入れ替え元を選べるようにし、入れ替え中は `終了` ボタンでモード解除できるようにした（長押しによる従来ショートカットは維持）。
- 変更箇所（主なファイル）: `lib/presentation/widgets/player_list_widgets.dart`, `lib/presentation/screens/player_list_screen.dart`, `lib/presentation/screens/match_history_screen.dart`。

### Testing
- `git diff --check` を実行して差分の問題は確認済みでエラーはありませんでした（成功）。
- `dart format` を実行しようとしましたが、実行環境に `dart` が存在しないため自動整形は実行できませんでした（未実行）。
- `flutter --version` を実行しようとしましたが、実行環境に `flutter` が存在しないため `flutter test` / `flutter analyze` 等の自動検証は実行できませんでした（未実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec7d2569ac8327ad95166647f6ae68)