### PR TITLE
Replace hardcoded small font sizes with Theme-driven text styles and make NavigationBar labels responsive

### DIFF
--- a/lib/presentation/screens/match_history_screen.dart
+++ b/lib/presentation/screens/match_history_screen.dart
@@ -331,8 +331,7 @@ class _MatchHistoryScreenState extends State<MatchHistoryScreen> {
               isSwapping
                   ? '入れ替える相手をタップしてください'
                   : '「選手を入れ替える」または長押しで開始できます',
-              style: TextStyle(
-                fontSize: 11,
+              style: theme.textTheme.bodySmall?.copyWith(
                 fontWeight: isSwapping ? FontWeight.bold : FontWeight.normal,
                 color: isSwapping
                     ? theme.colorScheme.onTertiaryContainer

--- a/lib/presentation/screens/player_list_screen.dart
+++ b/lib/presentation/screens/player_list_screen.dart
@@ -499,8 +499,9 @@ class _PlayerListScreenState extends State<PlayerListScreen> {
           Expanded(
             child: Text(
               'タップで本日の参加切替、⋯ボタン/長押しでメンバー編集',
-              style: TextStyle(
-                  fontSize: 11, color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
         ],
@@ -1286,8 +1287,10 @@ class _PlayerListScreenState extends State<PlayerListScreen> {
                                   ),
                                 ),
                                 title: Text(candidate.name),
-                                subtitle: Text(candidate.yomigana,
-                                    style: const TextStyle(fontSize: 11)),
+                                subtitle: Text(
+                                  candidate.yomigana,
+                                  style: Theme.of(context).textTheme.bodySmall,
+                                ),
                                 trailing: isCurrentPartner
                                     ? Icon(Icons.check_circle,
                                         color: Theme.of(context)
@@ -1615,11 +1618,13 @@ class _PlayerListScreenState extends State<PlayerListScreen> {
                                         ),
                                         child: Text(
                                           isMale ? '男' : '女',
-                                          style: TextStyle(
-                                            fontSize: 10,
-                                            color: genderColor,
-                                            fontWeight: FontWeight.bold,
-                                          ),
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .labelSmall
+                                              ?.copyWith(
+                                                color: genderColor,
+                                                fontWeight: FontWeight.bold,
+                                              ),
                                         ),
                                       ),
                                     ],
@@ -1763,11 +1768,13 @@ class _PlayerListScreenState extends State<PlayerListScreen> {
                                         ),
                                         child: Text(
                                           isMale ? '男' : '女',
-                                          style: TextStyle(
-                                            fontSize: 10,
-                                            color: genderColor,
-                                            fontWeight: FontWeight.bold,
-                                          ),
+                                          style: Theme.of(context)
+                                              .textTheme
+                                              .labelSmall
+                                              ?.copyWith(
+                                                color: genderColor,
+                                                fontWeight: FontWeight.bold,
+                                              ),
                                         ),
                                       ),
                                     ],

--- a/lib/presentation/screens/shuttle_calculation_screen.dart
+++ b/lib/presentation/screens/shuttle_calculation_screen.dart
@@ -585,8 +585,9 @@ class ShuttleCalculationPageState extends State<ShuttleCalculationScreen> {
                     if (entry.type == ExpenseType.shuttle)
                       Text(
                         '${entry.shuttleCount}個使用',
-                        style: TextStyle(
-                            fontSize: 11, color: theme.colorScheme.outline),
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.outline,
+                        ),
                       ),
                   ],
                 ),
@@ -767,8 +768,10 @@ class ShuttleCalculationPageState extends State<ShuttleCalculationScreen> {
                               ? Colors.blue
                               : Colors.pink,
                           child: Text(p.name.substring(0, 1),
-                              style: const TextStyle(
-                                  fontSize: 10, color: Colors.white)),
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelSmall
+                                  ?.copyWith(color: Colors.white)),
                         ),
                         label: Text(p.name),
                         selected: entry.payerId == p.id,
@@ -804,12 +807,10 @@ class ShuttleCalculationPageState extends State<ShuttleCalculationScreen> {
                           segments: const [
                             ButtonSegment(
                                 value: true,
-                                label: Text('ダース',
-                                    style: TextStyle(fontSize: 10))),
+                                label: Text('ダース')),
                             ButtonSegment(
                                 value: false,
-                                label:
-                                    Text('個', style: TextStyle(fontSize: 10))),
+                                label: Text('個')),
                           ],
                           selected: {entry.isPerDozen},
                           onSelectionChanged: (v) => setModalState(
@@ -1143,7 +1144,9 @@ class _SettlementSheetState extends State<_SettlementSheet> {
                         color: color)),
                 const SizedBox(height: 4),
                 Text('算定額: ¥$suggested',
-                    style: const TextStyle(fontSize: 11, color: Colors.grey)),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Colors.grey,
+                        )),
               ],
             ),
           ),

--- a/lib/presentation/theme/app_theme.dart
+++ b/lib/presentation/theme/app_theme.dart
@@ -25,6 +25,18 @@ class AppTheme {
       secondary: Colors.pink.shade600,
       tertiary: Colors.orange.shade700,
     );
+    final textTheme = GoogleFonts.notoSansJpTextTheme(
+      Theme.of(context).textTheme,
+    ).copyWith(
+      displayMedium: GoogleFonts.notoSansJp(
+        fontWeight: FontWeight.w900,
+        letterSpacing: 2.0,
+        color: const Color(0xFF2C3E50),
+      ),
+      labelLarge: GoogleFonts.kanit(
+        fontWeight: FontWeight.bold,
+      ),
+    );
 
     return ThemeData(
       colorScheme: colorScheme,
@@ -38,7 +50,10 @@ class AppTheme {
         backgroundColor: colorScheme.surface,
         indicatorColor: colorScheme.secondaryContainer,
         labelTextStyle: WidgetStateProperty.resolveWith((states) {
-          final style = TextStyle(fontSize: 11, fontWeight: FontWeight.w500);
+          final style = textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.w500,
+              ) ??
+              const TextStyle(fontWeight: FontWeight.w500);
           if (states.contains(WidgetState.selected)) {
             return style.copyWith(
               color: colorScheme.primary,
@@ -95,18 +110,7 @@ class AppTheme {
           ),
         ),
       ),
-      textTheme: GoogleFonts.notoSansJpTextTheme(
-        Theme.of(context).textTheme,
-      ).copyWith(
-        displayMedium: GoogleFonts.notoSansJp(
-          fontWeight: FontWeight.w900,
-          letterSpacing: 2.0,
-          color: const Color(0xFF2C3E50),
-        ),
-        labelLarge: GoogleFonts.kanit(
-          fontWeight: FontWeight.bold,
-        ),
-      ),
+      textTheme: textTheme,
     );
   }
 }

--- a/lib/presentation/widgets/common_widgets.dart
+++ b/lib/presentation/widgets/common_widgets.dart
@@ -53,6 +53,8 @@ class AppBadge extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textScaler = MediaQuery.textScalerOf(context);
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 8 * scale, vertical: 2 * scale),
       decoration: BoxDecoration(
@@ -75,11 +77,11 @@ class AppBadge extends StatelessWidget {
           ],
           Text(
             label,
-            style: TextStyle(
-              fontSize: 10 * scale,
+            textScaler: textScaler,
+            style: theme.textTheme.labelSmall?.copyWith(
+              fontSize: (theme.textTheme.labelSmall?.fontSize ?? 11) * scale,
               fontWeight: FontWeight.w900,
-              color:
-                  isFilled ? Theme.of(context).colorScheme.onPrimary : color,
+              color: isFilled ? theme.colorScheme.onPrimary : color,
             ),
           ),
         ],

--- a/lib/presentation/widgets/match_history_widgets.dart
+++ b/lib/presentation/widgets/match_history_widgets.dart
@@ -651,11 +651,10 @@ class RestingChip extends StatelessWidget {
               const SizedBox(width: 4),
               Text(
                 '$consecutiveRests',
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: FontWeight.bold,
-                  color: color,
-                ),
+                style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: color,
+                    ),
               ),
               const SizedBox(width: 4),
             ],
@@ -721,6 +720,7 @@ class MatchHistoryHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textScaler = MediaQuery.textScalerOf(context);
     if (isSwapping) {
       return Row(children: [
         const Icon(Icons.swap_horiz, color: Colors.white, size: 28),
@@ -750,17 +750,27 @@ class MatchHistoryHeader extends StatelessWidget {
           onPressed:
               currentIndex! > 0 ? () => onIndexChange(currentIndex! - 1) : null,
         ),
-        Column(mainAxisSize: MainAxisSize.min, children: [
-          Text(
-            'MATCH ${session!.index}',
-            style: const TextStyle(
-                color: Colors.white, fontWeight: FontWeight.bold, fontSize: 18),
-          ),
-          Text(
-            '$total 試合中 ${currentIndex! + 1} 試合目',
-            style: const TextStyle(color: Colors.white70, fontSize: 10),
-          ),
-        ]),
+        Flexible(
+          child: Column(mainAxisSize: MainAxisSize.min, children: [
+            Text(
+              'MATCH ${session!.index}',
+              textScaler: textScaler,
+              style: const TextStyle(
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18),
+            ),
+            Text(
+              '$total 試合中 ${currentIndex! + 1} 試合目',
+              textScaler: textScaler,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Colors.white70,
+                  ),
+            ),
+          ]),
+        ),
         IconButton(
           icon: const Icon(Icons.chevron_right, color: Colors.white),
           onPressed: currentIndex! < total - 1

--- a/lib/presentation/widgets/player_list_widgets.dart
+++ b/lib/presentation/widgets/player_list_widgets.dart
@@ -261,8 +261,7 @@ class _PlayerChipStats extends StatelessWidget {
             const SizedBox(width: AppSpacing.sm),
             Text(
               '${player.gender == Gender.male ? "男" : "女"}$sameGenderCount 混$mxCount',
-              style: TextStyle(
-                fontSize: 10,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
                 color: token.statsTextColor,
                 fontWeight: FontWeight.w600,
               ),

--- a/lib/presentation/widgets/shuttle_history_dialog.dart
+++ b/lib/presentation/widgets/shuttle_history_dialog.dart
@@ -167,9 +167,10 @@ class _ShuttleHistoryDialogState extends State<ShuttleHistoryDialog> {
                                       ),
                                       Text(
                                         '使用シャトル',
-                                        style: TextStyle(
-                                            fontSize: 11,
-                                            color: theme.colorScheme.outline),
+                                        style: theme.textTheme.bodySmall
+                                            ?.copyWith(
+                                          color: theme.colorScheme.outline,
+                                        ),
                                       ),
                                     ],
                                   ),
@@ -197,10 +198,11 @@ class _ShuttleHistoryDialogState extends State<ShuttleHistoryDialog> {
                                       children: [
                                         Text(
                                           e.key.displayName,
-                                          style: TextStyle(
-                                              fontSize: 11,
-                                              color: theme.colorScheme
-                                                  .onSurfaceVariant),
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
+                                            color: theme
+                                                .colorScheme.onSurfaceVariant,
+                                          ),
                                         ),
                                         const SizedBox(width: 4),
                                         Text(

--- a/lib/presentation/widgets/shuttle_stock_dialog.dart
+++ b/lib/presentation/widgets/shuttle_stock_dialog.dart
@@ -330,11 +330,15 @@ class _ShuttleStockDialogState extends State<ShuttleStockDialog> {
                                               ),
                                               child: Text(
                                                 payer.name,
-                                                style: TextStyle(
-                                                    fontSize: 11,
-                                                    fontWeight: FontWeight.w500,
-                                                    color: theme.colorScheme
-                                                        .onSurfaceVariant),
+                                                style: theme
+                                                    .textTheme
+                                                    .labelMedium
+                                                    ?.copyWith(
+                                                      fontWeight:
+                                                          FontWeight.w500,
+                                                      color: theme.colorScheme
+                                                          .onSurfaceVariant,
+                                                    ),
                                               ),
                                             ),
                                           ],


### PR DESCRIPTION
### Motivation
- Remove hardcoded `fontSize: 10/11` usages so small/helper text follows the app `TextTheme` and respects user text-scaling and accessibility settings.
- Ensure `NavigationBarThemeData.labelTextStyle` is derived from the app `TextTheme` (not a fixed 11) to keep navigation labels consistent and readable.

### Description
- Create a reusable `textTheme` in `AppTheme.light` and set `ThemeData.textTheme` to that value, then derive `NavigationBarThemeData.labelTextStyle` from `textTheme.labelMedium` instead of a fixed `TextStyle(fontSize: 11)`.
- Replace hardcoded `fontSize: 10/11` occurrences with appropriate `Theme.of(context).textTheme` styles (`bodySmall`, `labelSmall`, `labelMedium`) across player list, match history, shuttle calculation, shuttle dialogs, and badge components.
- Add `MediaQuery.textScalerOf(context)` usage in compact badges and match header text and apply `Flexible` + `maxLines: 1` + `ellipsis` in the compact match header to improve layout resilience when text scaling is large.

### Testing
- Ran a repository-wide search (`rg`) to verify there are no remaining hardcoded `fontSize: 10/11` matches under `lib/`, and the check succeeded.
- Attempted to run `dart format` but the environment lacks the `dart` binary so formatting could not be executed.
- Attempted to run `flutter --version` but the environment lacks the `flutter` binary so Flutter-based tests/validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec809ca30883278fe808f4bacff9ce)