### PR TITLE
Refactor OtherScreen into accessible section cards with inquiry CTA and release notes inline/modal

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,50 @@
 {
   "@@locale": "en",
-  "appTitle": "Game Member Generator"
+  "appTitle": "Game Member Generator",
+  "otherSupportSectionTitle": "Support",
+  "otherSupportSectionSubtitle": "Quick access to inquiries and the user guide.",
+  "otherInquiryCta": "Choose category",
+  "otherInquirySemantic": "Inquiry and feedback. Opens category selection in one tap.",
+  "otherInquirySemanticHint": "Tap to choose an inquiry category.",
+  "otherInquiryBottomSheetHint": "Tap to open the external form.",
+  "otherManualSubtitle": "Review basic operations and workflow.",
+  "otherManualSemantic": "Manual. Opens the app usage guide.",
+  "otherOpenScreenSemanticHint": "Tap to open the screen.",
+  "otherAppInfoSectionTitle": "App info",
+  "otherAppInfoSectionSubtitle": "Check version, updates, and policy details.",
+  "otherLatestUpdateInline": "Latest v{version} ({date})\\n{highlight}",
+  "@otherLatestUpdateInline": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      },
+      "date": {
+        "type": "String"
+      },
+      "highlight": {
+        "type": "String"
+      }
+    }
+  },
+  "otherNoReleaseHistory": "No release history yet.",
+  "otherLatestUpdateDetails": "Latest update details",
+  "otherViewAllUpdateHistory": "View full history",
+  "otherVersionSemantic": "Version info {version} and latest updates.",
+  "@otherVersionSemantic": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "otherReleaseDetailsSemanticHint": "Tap to open update details in a modal.",
+  "otherPrivacySubtitle": "Review the privacy handling policy.",
+  "otherPrivacySemantic": "Privacy policy. Shows data collection and usage policy.",
+  "otherOpenSheetSemanticHint": "Tap to open a modal sheet.",
+  "otherLicenseSubtitle": "View licenses for third-party libraries.",
+  "otherLicenseSemantic": "License information. Opens OSS license list.",
+  "otherCommunitySectionTitle": "Community / Support",
+  "otherCommunitySectionSubtitle": "Support the app’s ongoing development.",
+  "otherCommunitySupportSemantic": "Support page. Helps the developer on an external site.",
+  "otherExternalLinkSemanticHint": "Tap to show a confirmation dialog before opening an external site."
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -39,11 +39,32 @@
   "otherUnknown": "Unknown",
   "otherWeb": "Web",
   "otherAndroid": "Android {release}",
-  "@otherAndroid": {"placeholders": {"release": {"type": "String"}}},
+  "@otherAndroid": {
+    "placeholders": {
+      "release": {
+        "type": "String"
+      }
+    }
+  },
   "otherIos": "iOS {version}",
-  "@otherIos": {"placeholders": {"version": {"type": "String"}}},
+  "@otherIos": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
   "otherInquiryTemplate": "【環境情報】\nApp: v{appVersion}\nOS: {osVersion}\n\n【お問い合わせ内容】\n",
-  "@otherInquiryTemplate": {"placeholders": {"appVersion": {"type": "String"}, "osVersion": {"type": "String"}}},
+  "@otherInquiryTemplate": {
+    "placeholders": {
+      "appVersion": {
+        "type": "String"
+      },
+      "osVersion": {
+        "type": "String"
+      }
+    }
+  },
   "otherOpenFormFailed": "フォームを開けませんでした",
   "otherPrivacyPolicy": "プライバシーポリシー",
   "otherPrivacySection1Title": "1. 情報の収集",
@@ -60,12 +81,67 @@
   "otherInquirySubtitle": "不具合の報告や機能改善の要望はこちら",
   "otherVersion": "バージョン",
   "otherVersionBuild": "{version} (Build: {buildDate})",
-  "@otherVersionBuild": {"placeholders": {"version": {"type": "String"}, "buildDate": {"type": "String"}}},
+  "@otherVersionBuild": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      },
+      "buildDate": {
+        "type": "String"
+      }
+    }
+  },
   "otherLicenseInfo": "ライセンス情報",
   "otherSupportTitle": "🏸 応援する",
   "otherSupportSubtitle": "開発者が無償で作成しています。\n練習のお供に役立ったら、ぜひ応援をお願いします！",
   "otherMoveToExternal": "外部サイトへ移動",
   "otherMoveToExternalDescription": "応援ページ（外部サイト）へ移動します。よろしいですか？",
+  "otherSupportSectionTitle": "サポート",
+  "otherSupportSectionSubtitle": "お問い合わせや使い方ガイドにすぐアクセスできます。",
+  "otherInquiryCta": "カテゴリを選択",
+  "otherInquirySemantic": "ご意見・お問い合わせ。1タップでカテゴリ選択へ進みます。",
+  "otherInquirySemanticHint": "タップしてお問い合わせカテゴリを選択します。",
+  "otherInquiryBottomSheetHint": "タップして外部フォームを開きます。",
+  "otherManualSubtitle": "基本操作と進行手順を確認できます。",
+  "otherManualSemantic": "マニュアル。アプリの使い方ガイドを開きます。",
+  "otherOpenScreenSemanticHint": "タップして画面を開きます。",
+  "otherAppInfoSectionTitle": "アプリ情報",
+  "otherAppInfoSectionSubtitle": "バージョンや更新内容、ポリシーを確認できます。",
+  "otherLatestUpdateInline": "最新 v{version} ({date})\n{highlight}",
+  "@otherLatestUpdateInline": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      },
+      "date": {
+        "type": "String"
+      },
+      "highlight": {
+        "type": "String"
+      }
+    }
+  },
+  "otherNoReleaseHistory": "更新履歴はまだありません。",
+  "otherLatestUpdateDetails": "最新アップデートの詳細",
+  "otherViewAllUpdateHistory": "すべての履歴を見る",
+  "otherVersionSemantic": "バージョン情報 {version} と最新更新内容を表示します。",
+  "@otherVersionSemantic": {
+    "placeholders": {
+      "version": {
+        "type": "String"
+      }
+    }
+  },
+  "otherReleaseDetailsSemanticHint": "タップして更新内容の詳細モーダルを開きます。",
+  "otherPrivacySubtitle": "個人情報の取り扱い方針を確認できます。",
+  "otherPrivacySemantic": "プライバシーポリシー。情報の収集と利用方針を表示します。",
+  "otherOpenSheetSemanticHint": "タップしてモーダルを開きます。",
+  "otherLicenseSubtitle": "利用ライブラリのライセンス一覧を確認できます。",
+  "otherLicenseSemantic": "ライセンス情報。OSSライセンス一覧を開きます。",
+  "otherCommunitySectionTitle": "コミュニティ / 応援",
+  "otherCommunitySectionSubtitle": "アプリの継続開発を応援できます。",
+  "otherCommunitySupportSemantic": "応援ページ。外部サイトで開発者を支援します。",
+  "otherExternalLinkSemanticHint": "タップすると外部サイトへ移動確認ダイアログを表示します。",
   "commonCancel": "キャンセル",
   "otherMove": "移動する"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -72,7 +72,31 @@ class AppLocalizations {
     'otherManual': 'マニュアル',
     'otherInquiry': 'ご意見・お問い合わせ',
     'otherInquirySubtitle': '不具合の報告や機能改善の要望はこちら',
+    'otherInquiryCta': 'カテゴリを選択',
+    'otherInquirySemantic': 'ご意見・お問い合わせ。1タップでカテゴリ選択へ進みます。',
+    'otherInquirySemanticHint': 'タップしてお問い合わせカテゴリを選択します。',
+    'otherInquiryBottomSheetHint': 'タップして外部フォームを開きます。',
     'otherVersion': 'バージョン',
+    'otherNoReleaseHistory': '更新履歴はまだありません。',
+    'otherLatestUpdateDetails': '最新アップデートの詳細',
+    'otherViewAllUpdateHistory': 'すべての履歴を見る',
+    'otherReleaseDetailsSemanticHint': 'タップして更新内容の詳細モーダルを開きます。',
+    'otherManualSubtitle': '基本操作と進行手順を確認できます。',
+    'otherManualSemantic': 'マニュアル。アプリの使い方ガイドを開きます。',
+    'otherOpenScreenSemanticHint': 'タップして画面を開きます。',
+    'otherSupportSectionTitle': 'サポート',
+    'otherSupportSectionSubtitle': 'お問い合わせや使い方ガイドにすぐアクセスできます。',
+    'otherAppInfoSectionTitle': 'アプリ情報',
+    'otherAppInfoSectionSubtitle': 'バージョンや更新内容、ポリシーを確認できます。',
+    'otherPrivacySubtitle': '個人情報の取り扱い方針を確認できます。',
+    'otherPrivacySemantic': 'プライバシーポリシー。情報の収集と利用方針を表示します。',
+    'otherOpenSheetSemanticHint': 'タップしてモーダルを開きます。',
+    'otherLicenseSubtitle': '利用ライブラリのライセンス一覧を確認できます。',
+    'otherLicenseSemantic': 'ライセンス情報。OSSライセンス一覧を開きます。',
+    'otherCommunitySectionTitle': 'コミュニティ / 応援',
+    'otherCommunitySectionSubtitle': 'アプリの継続開発を応援できます。',
+    'otherCommunitySupportSemantic': '応援ページ。外部サイトで開発者を支援します。',
+    'otherExternalLinkSemanticHint': 'タップすると外部サイトへ移動確認ダイアログを表示します。',
     'otherLicenseInfo': 'ライセンス情報',
     'otherSupportTitle': '🏸 応援する',
     'otherSupportSubtitle': '開発者が無償で作成しています。\n練習のお供に役立ったら、ぜひ応援をお願いします！',
@@ -140,7 +164,34 @@ class AppLocalizations {
   String get otherManual => _text('otherManual');
   String get otherInquiry => _text('otherInquiry');
   String get otherInquirySubtitle => _text('otherInquirySubtitle');
+  String get otherInquiryCta => _text('otherInquiryCta');
+  String get otherInquirySemantic => _text('otherInquirySemantic');
+  String get otherInquirySemanticHint => _text('otherInquirySemanticHint');
+  String get otherInquiryBottomSheetHint => _text('otherInquiryBottomSheetHint');
   String get otherVersion => _text('otherVersion');
+  String otherLatestUpdateInline(String version, String date, String highlight) =>
+      '最新 v$version ($date)\n$highlight';
+  String get otherNoReleaseHistory => _text('otherNoReleaseHistory');
+  String get otherLatestUpdateDetails => _text('otherLatestUpdateDetails');
+  String get otherViewAllUpdateHistory => _text('otherViewAllUpdateHistory');
+  String otherVersionSemantic(String version) => 'バージョン情報 $version と最新更新内容を表示します。';
+  String get otherReleaseDetailsSemanticHint => _text('otherReleaseDetailsSemanticHint');
+  String get otherManualSubtitle => _text('otherManualSubtitle');
+  String get otherManualSemantic => _text('otherManualSemantic');
+  String get otherOpenScreenSemanticHint => _text('otherOpenScreenSemanticHint');
+  String get otherSupportSectionTitle => _text('otherSupportSectionTitle');
+  String get otherSupportSectionSubtitle => _text('otherSupportSectionSubtitle');
+  String get otherAppInfoSectionTitle => _text('otherAppInfoSectionTitle');
+  String get otherAppInfoSectionSubtitle => _text('otherAppInfoSectionSubtitle');
+  String get otherPrivacySubtitle => _text('otherPrivacySubtitle');
+  String get otherPrivacySemantic => _text('otherPrivacySemantic');
+  String get otherOpenSheetSemanticHint => _text('otherOpenSheetSemanticHint');
+  String get otherLicenseSubtitle => _text('otherLicenseSubtitle');
+  String get otherLicenseSemantic => _text('otherLicenseSemantic');
+  String get otherCommunitySectionTitle => _text('otherCommunitySectionTitle');
+  String get otherCommunitySectionSubtitle => _text('otherCommunitySectionSubtitle');
+  String get otherCommunitySupportSemantic => _text('otherCommunitySupportSemantic');
+  String get otherExternalLinkSemanticHint => _text('otherExternalLinkSemanticHint');
   String otherVersionBuild(String version, String buildDate) => '$version (Build: $buildDate)';
   String get otherLicenseInfo => _text('otherLicenseInfo');
   String get otherSupportTitle => _text('otherSupportTitle');

--- a/lib/presentation/screens/other_screen.dart
+++ b/lib/presentation/screens/other_screen.dart
@@ -24,21 +24,24 @@ class OtherScreen extends StatefulWidget {
 
 class _OtherScreenState extends State<OtherScreen> {
   String _versionText = '';
+  String _versionFallbackText = '';
   List<ReleaseNote> _loadedReleaseNotes = [];
+  bool _isInitialized = false;
 
   ReleaseNote? get _latestReleaseNote =>
       _loadedReleaseNotes.isEmpty ? null : _loadedReleaseNotes.first;
 
   @override
-  void initState() {
-    super.initState();
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_isInitialized) return;
+    _isInitialized = true;
+    _versionFallbackText = AppLocalizations.of(context).otherVersionFallback;
+    _versionText = _versionFallbackText;
     _loadInitialData();
   }
 
   Future<void> _loadInitialData() async {
-    if (mounted) {
-      _versionText = AppLocalizations.of(context).otherVersionFallback;
-    }
     await Future.wait([
       _loadVersion(),
       _loadNotes(),
@@ -91,7 +94,7 @@ class _OtherScreenState extends State<OtherScreen> {
 
   String get _latestReleaseVersionText {
     if (_loadedReleaseNotes.isEmpty) {
-      return AppLocalizations.of(context).otherVersionFallback;
+      return _versionFallbackText;
     }
     return 'v${_loadedReleaseNotes.first.version}';
   }

--- a/lib/presentation/screens/other_screen.dart
+++ b/lib/presentation/screens/other_screen.dart
@@ -26,6 +26,9 @@ class _OtherScreenState extends State<OtherScreen> {
   String _versionText = '';
   List<ReleaseNote> _loadedReleaseNotes = [];
 
+  ReleaseNote? get _latestReleaseNote =>
+      _loadedReleaseNotes.isEmpty ? null : _loadedReleaseNotes.first;
+
   @override
   void initState() {
     super.initState();
@@ -101,7 +104,7 @@ class _OtherScreenState extends State<OtherScreen> {
     };
   }
 
-  Future<void> _showReleaseNotes() async {
+  Future<void> _showReleaseHistory() async {
     final l10n = AppLocalizations.of(context);
     await showModalBottomSheet<void>(
       context: context,
@@ -127,43 +130,55 @@ class _OtherScreenState extends State<OtherScreen> {
                     separatorBuilder: (_, __) => const Divider(height: 20),
                     itemBuilder: (context, index) {
                       final note = _loadedReleaseNotes[index];
-                      return Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                'v${note.version}',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .titleMedium
-                                    ?.copyWith(
-                                      fontWeight: FontWeight.bold,
-                                    ),
-                              ),
-                              Text(
-                                note.date,
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .bodySmall
-                                    ?.copyWith(
-                                      color:
-                                          Theme.of(context).colorScheme.outline,
-                                    ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 8),
-                          ...note.changes.map(
-                            (change) => Padding(
-                              padding: const EdgeInsets.only(bottom: 4),
-                              child: Text('• $change'),
-                            ),
-                          ),
-                        ],
-                      );
+                      return _ReleaseNoteContent(note: note);
                     },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _showLatestReleaseDetails() async {
+    final l10n = AppLocalizations.of(context);
+    final latestNote = _latestReleaseNote;
+    if (latestNote == null) return;
+
+    await showModalBottomSheet<void>(
+      context: context,
+      showDragHandle: true,
+      isScrollControlled: true,
+      builder: (context) {
+        return SafeArea(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  l10n.otherLatestUpdateDetails,
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                const SizedBox(height: 12),
+                Flexible(
+                  child: SingleChildScrollView(
+                    child: _ReleaseNoteContent(note: latestNote),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      _showReleaseHistory();
+                    },
+                    icon: const Icon(Icons.history),
+                    label: Text(l10n.otherViewAllUpdateHistory),
                   ),
                 ),
               ],
@@ -191,19 +206,25 @@ class _OtherScreenState extends State<OtherScreen> {
                   style: Theme.of(context).textTheme.titleLarge,
                 ),
               ),
-              ListTile(
+              _buildSemanticTile(
                 leading: const Icon(Icons.bug_report_outlined),
-                title: Text(l10n.otherInquiryReportBug),
+                title: l10n.otherInquiryReportBug,
+                semanticLabel: l10n.otherInquiryReportBug,
+                semanticHint: l10n.otherInquiryBottomSheetHint,
                 onTap: () => _launchInquiry(InquiryCategory.bug),
               ),
-              ListTile(
+              _buildSemanticTile(
                 leading: const Icon(Icons.lightbulb_outline),
-                title: Text(l10n.otherInquiryRequestFeature),
+                title: l10n.otherInquiryRequestFeature,
+                semanticLabel: l10n.otherInquiryRequestFeature,
+                semanticHint: l10n.otherInquiryBottomSheetHint,
                 onTap: () => _launchInquiry(InquiryCategory.request),
               ),
-              ListTile(
+              _buildSemanticTile(
                 leading: const Icon(Icons.chat_outlined),
-                title: Text(l10n.otherInquiryElse),
+                title: l10n.otherInquiryElse,
+                semanticLabel: l10n.otherInquiryElse,
+                semanticHint: l10n.otherInquiryBottomSheetHint,
                 onTap: () => _launchInquiry(InquiryCategory.other),
               ),
               const SizedBox(height: 16),
@@ -236,7 +257,8 @@ class _OtherScreenState extends State<OtherScreen> {
     final Uri url = Uri.parse(formBaseUrl).replace(queryParameters: {
       'usp': 'pp_url',
       'entry.371796673': _inquiryLabel(l10n, category),
-      'entry.1693838828': l10n.otherInquiryTemplate(packageInfo.version, osVersion),
+      'entry.1693838828':
+          l10n.otherInquiryTemplate(packageInfo.version, osVersion),
     });
 
     if (await canLaunchUrl(url)) {
@@ -274,20 +296,28 @@ class _OtherScreenState extends State<OtherScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(l10n.otherPrivacySection1Title,
-                            style: const TextStyle(fontWeight: FontWeight.bold)),
+                        Text(
+                          l10n.otherPrivacySection1Title,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
                         Text(l10n.otherPrivacySection1Body),
                         const SizedBox(height: 12),
-                        Text(l10n.otherPrivacySection2Title,
-                            style: const TextStyle(fontWeight: FontWeight.bold)),
+                        Text(
+                          l10n.otherPrivacySection2Title,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
                         Text(l10n.otherPrivacySection2Body),
                         const SizedBox(height: 12),
-                        Text(l10n.otherPrivacySection3Title,
-                            style: const TextStyle(fontWeight: FontWeight.bold)),
+                        Text(
+                          l10n.otherPrivacySection3Title,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
                         Text(l10n.otherPrivacySection3Body),
                         const SizedBox(height: 12),
-                        Text(l10n.otherPrivacySection4Title,
-                            style: const TextStyle(fontWeight: FontWeight.bold)),
+                        Text(
+                          l10n.otherPrivacySection4Title,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
+                        ),
                         Text(l10n.otherPrivacySection4Body),
                       ],
                     ),
@@ -298,6 +328,70 @@ class _OtherScreenState extends State<OtherScreen> {
           ),
         );
       },
+    );
+  }
+
+  Widget _buildSemanticTile({
+    required Widget leading,
+    required String title,
+    String? subtitle,
+    required String semanticLabel,
+    required String semanticHint,
+    VoidCallback? onTap,
+    Widget? trailing,
+  }) {
+    return Semantics(
+      button: onTap != null,
+      label: semanticLabel,
+      hint: semanticHint,
+      child: ListTile(
+        leading: leading,
+        title: Text(title),
+        subtitle: subtitle == null ? null : Text(subtitle),
+        trailing: trailing ?? const Icon(Icons.chevron_right),
+        onTap: onTap,
+      ),
+    );
+  }
+
+  Future<void> _openSupportPage() async {
+    final l10n = AppLocalizations.of(context);
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.otherMoveToExternal),
+        content: Text(l10n.otherMoveToExternalDescription),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.commonCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(l10n.otherMove),
+          ),
+        ],
+      ),
+    );
+
+    if (ok == true) {
+      final url = Uri.parse('https://ofuse.me/37202113/letter');
+      if (await canLaunchUrl(url)) {
+        await launchUrl(url, mode: LaunchMode.externalApplication);
+      }
+    }
+  }
+
+  String _latestInlineSummary(AppLocalizations l10n) {
+    final latest = _latestReleaseNote;
+    if (latest == null) {
+      return l10n.otherNoReleaseHistory;
+    }
+    final firstChange = latest.changes.isEmpty ? '' : latest.changes.first;
+    return l10n.otherLatestUpdateInline(
+      latest.version,
+      latest.date,
+      firstChange,
     );
   }
 
@@ -316,89 +410,179 @@ class _OtherScreenState extends State<OtherScreen> {
         centerTitle: true,
       ),
       body: ListView(
+        padding: const EdgeInsets.fromLTRB(12, 12, 12, 20),
         children: [
-          ListTile(
-            leading: const Icon(Icons.menu_book_outlined),
-            title: Text(l10n.otherManual),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () {
-              Navigator.of(context).push(
-                MaterialPageRoute<void>(
-                  builder: (_) => const ManualScreen(),
+          _SectionCard(
+            title: l10n.otherSupportSectionTitle,
+            subtitle: l10n.otherSupportSectionSubtitle,
+            children: [
+              _buildSemanticTile(
+                leading: const Icon(Icons.feedback_outlined),
+                title: l10n.otherInquiry,
+                subtitle: l10n.otherInquirySubtitle,
+                semanticLabel: l10n.otherInquirySemantic,
+                semanticHint: l10n.otherInquirySemanticHint,
+                trailing: FilledButton.tonalIcon(
+                  onPressed: _showInquiryOptions,
+                  icon: const Icon(Icons.arrow_forward),
+                  label: Text(l10n.otherInquiryCta),
                 ),
-              );
-            },
-          ),
-          const Divider(height: 0),
-          ListTile(
-            leading: const Icon(Icons.feedback_outlined),
-            title: Text(l10n.otherInquiry),
-            subtitle: Text(l10n.otherInquirySubtitle),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: _showInquiryOptions,
-          ),
-          const Divider(height: 0),
-          ListTile(
-            leading: const Icon(Icons.tag_outlined),
-            title: Text(l10n.otherVersion),
-            subtitle: Text(l10n.otherVersionBuild(_versionText, AppConfig.buildDate)),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: _showReleaseNotes,
-          ),
-          const Divider(height: 0),
-          ListTile(
-            leading: const Icon(Icons.description_outlined),
-            title: Text(l10n.otherPrivacyPolicy),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: _showPrivacyPolicy,
-          ),
-          const Divider(height: 0),
-          ListTile(
-            leading: const Icon(Icons.info_outline),
-            title: Text(l10n.otherLicenseInfo),
-            trailing: const Icon(Icons.chevron_right),
-            onTap: () {
-              showLicensePage(
-                context: context,
-                applicationName: l10n.appTitle,
-                applicationVersion: _versionText,
-              );
-            },
-          ),
-          const Divider(height: 0),
-          ListTile(
-            leading: const Icon(Icons.volunteer_activism_outlined),
-            title: Text(l10n.otherSupportTitle),
-            subtitle: Text(l10n.otherSupportSubtitle),
-            onTap: () async {
-              final ok = await showDialog<bool>(
-                context: context,
-                builder: (context) => AlertDialog(
-                  title: Text(l10n.otherMoveToExternal),
-                  content: Text(l10n.otherMoveToExternalDescription),
-                  actions: [
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(false),
-                      child: Text(l10n.commonCancel),
+                onTap: _showInquiryOptions,
+              ),
+              const Divider(height: 0),
+              _buildSemanticTile(
+                leading: const Icon(Icons.menu_book_outlined),
+                title: l10n.otherManual,
+                subtitle: l10n.otherManualSubtitle,
+                semanticLabel: l10n.otherManualSemantic,
+                semanticHint: l10n.otherOpenScreenSemanticHint,
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute<void>(
+                      builder: (_) => const ManualScreen(),
                     ),
-                    TextButton(
-                      onPressed: () => Navigator.of(context).pop(true),
-                      child: Text(l10n.otherMove),
-                    ),
-                  ],
-                ),
-              );
-
-              if (ok == true) {
-                final url = Uri.parse('https://ofuse.me/37202113/letter');
-                if (await canLaunchUrl(url)) {
-                  await launchUrl(url, mode: LaunchMode.externalApplication);
-                }
-              }
-            },
+                  );
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _SectionCard(
+            title: l10n.otherAppInfoSectionTitle,
+            subtitle: l10n.otherAppInfoSectionSubtitle,
+            children: [
+              _buildSemanticTile(
+                leading: const Icon(Icons.tag_outlined),
+                title: l10n.otherVersion,
+                subtitle:
+                    '${l10n.otherVersionBuild(_versionText, AppConfig.buildDate)}\n${_latestInlineSummary(l10n)}',
+                semanticLabel: l10n.otherVersionSemantic(_versionText),
+                semanticHint: l10n.otherReleaseDetailsSemanticHint,
+                onTap: _showLatestReleaseDetails,
+              ),
+              const Divider(height: 0),
+              _buildSemanticTile(
+                leading: const Icon(Icons.description_outlined),
+                title: l10n.otherPrivacyPolicy,
+                subtitle: l10n.otherPrivacySubtitle,
+                semanticLabel: l10n.otherPrivacySemantic,
+                semanticHint: l10n.otherOpenSheetSemanticHint,
+                onTap: _showPrivacyPolicy,
+              ),
+              const Divider(height: 0),
+              _buildSemanticTile(
+                leading: const Icon(Icons.info_outline),
+                title: l10n.otherLicenseInfo,
+                subtitle: l10n.otherLicenseSubtitle,
+                semanticLabel: l10n.otherLicenseSemantic,
+                semanticHint: l10n.otherOpenScreenSemanticHint,
+                onTap: () {
+                  showLicensePage(
+                    context: context,
+                    applicationName: l10n.appTitle,
+                    applicationVersion: _versionText,
+                  );
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          _SectionCard(
+            title: l10n.otherCommunitySectionTitle,
+            subtitle: l10n.otherCommunitySectionSubtitle,
+            children: [
+              _buildSemanticTile(
+                leading: const Icon(Icons.volunteer_activism_outlined),
+                title: l10n.otherSupportTitle,
+                subtitle: l10n.otherSupportSubtitle,
+                semanticLabel: l10n.otherCommunitySupportSemantic,
+                semanticHint: l10n.otherExternalLinkSemanticHint,
+                onTap: _openSupportPage,
+              ),
+            ],
           ),
         ],
       ),
+    );
+  }
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({
+    required this.title,
+    required this.subtitle,
+    required this.children,
+  });
+
+  final String title;
+  final String subtitle;
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: textTheme.titleMedium
+                      ?.copyWith(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 4),
+                Text(subtitle, style: textTheme.bodySmall),
+              ],
+            ),
+          ),
+          ...children,
+        ],
+      ),
+    );
+  }
+}
+
+class _ReleaseNoteContent extends StatelessWidget {
+  const _ReleaseNoteContent({required this.note});
+
+  final ReleaseNote note;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'v${note.version}',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            Text(
+              note.date,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        ...note.changes.map(
+          (change) => Padding(
+            padding: const EdgeInsets.only(bottom: 4),
+            child: Text('• $change'),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Make the "Other" screen clearer by grouping related items into visual section cards (Support, App Info, Community/Support). 
- Turn inquiry flow into a one-tap CTA to streamline reporting/requests and reduce friction when opening the inquiry form. 
- Improve accessibility by providing semantic labels/hints and descriptive subtitles so screen readers and sighted users receive the same contextual information. 

### Description
- Reorganized `OtherScreen` UI into three cards by adding `_SectionCard` and moving items into `Support`, `App Info`, and `Community / Support` groups in `lib/presentation/screens/other_screen.dart`. 
- Converted inquiry tile to a CTA using `FilledButton.tonalIcon` inside the tile and retained tile tap to open the category-selection bottom sheet, implemented `_buildSemanticTile` for semantic wrappers. 
- Show latest release inline (`version/date/highlight`) in the Version tile and added `_showLatestReleaseDetails` modal with a link to the full release-history modal; factored release rendering into `_ReleaseNoteContent`. 
- Added/updated localization keys in `lib/l10n/app_ja.arb` and `lib/l10n/app_en.arb` and exposed new getters/methods in `lib/l10n/app_localizations.dart` to support new UI text and accessibility strings. 

### Testing
- Attempted `flutter gen-l10n` to regenerate localization artifacts but it failed in the environment with `flutter: command not found`. 
- No other automated Flutter/Dart tests were run in this container because the Flutter/Dart SDK is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec9fa2da488327af44e78fef16283e)