### PR TITLE
Avoid `Isolate.run` on Web in MatchMakingService

### DIFF
--- a/lib/domain/services/match_making_service.dart
+++ b/lib/domain/services/match_making_service.dart
@@ -1,6 +1,8 @@
 import 'dart:developer' as dev;
 import 'dart:isolate';
 
+import 'package:flutter/foundation.dart';
+
 import 'package:game_member_generator/domain/entities/player.dart';
 import 'package:game_member_generator/domain/entities/player_stats_pool.dart';
 
@@ -67,24 +69,7 @@ class MatchMakingService {
 
     late final List<_GameDto> gameDtos;
     try {
-      gameDtos = await Isolate.run(
-        () {
-          final domainMatchTypes = matchDto.matchTypeIndexes
-              .map((index) => MatchType.values[index])
-              .toList(growable: false);
-
-          final domainPool = matchDto.toDomainPool();
-          final generatedGames = algorithm.generateMatches(
-            matchTypes: domainMatchTypes,
-            playerPool: domainPool,
-          );
-
-          return generatedGames
-              .map((game) => _GameDto.fromDomain(game))
-              .toList(growable: false);
-        },
-        debugName: 'matchmaking_search_isolate',
-      );
+      gameDtos = await _generateGameDtos(matchDto);
     } finally {
       final endAt = DateTime.now();
       dev.Timeline.instantSync(
@@ -114,6 +99,33 @@ class MatchMakingService {
     return MatchGenerationResult(
       games: games,
       restingPlayers: restingPlayers,
+    );
+  }
+
+  Future<List<_GameDto>> _generateGameDtos(_MatchGenerationInputDto matchDto) async {
+    List<_GameDto> runGeneration() {
+      final domainMatchTypes = matchDto.matchTypeIndexes
+          .map((index) => MatchType.values[index])
+          .toList(growable: false);
+
+      final domainPool = matchDto.toDomainPool();
+      final generatedGames = algorithm.generateMatches(
+        matchTypes: domainMatchTypes,
+        playerPool: domainPool,
+      );
+
+      return generatedGames
+          .map((game) => _GameDto.fromDomain(game))
+          .toList(growable: false);
+    }
+
+    if (kIsWeb) {
+      return runGeneration();
+    }
+
+    return Isolate.run(
+      runGeneration,
+      debugName: 'matchmaking_search_isolate',
     );
   }
 }


### PR DESCRIPTION
### Motivation
- Web builds failed during match generation with `Unsupported operation: new RawReceivePort` because `Isolate.run` uses platform features not available in browser environments.

### Description
- Added `import 'package:flutter/foundation.dart'` and introduced a new helper `Future<List<_GameDto>> _generateGameDtos(_MatchGenerationInputDto)` to encapsulate match generation.
- The helper uses `kIsWeb` to run the generation synchronously on Web and falls back to `Isolate.run` for non-Web platforms, preserving background execution behavior.
- Refactored `generateMatchSession` to call `_generateGameDtos(matchDto)` and removed the direct `Isolate.run` usage from that method.

### Testing
- Attempted to run `dart format lib/domain/services/match_making_service.dart` and `flutter test test/domain/services/match_making_service_test.dart`, but the environment lacks the `dart`/`flutter` binaries so tests could not be executed.
- No automated tests were run successfully in this environment; please run `flutter test` and verify match generation on Web and non-Web platforms locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f3176a008327b35d468661e833e5)